### PR TITLE
Fixes #4

### DIFF
--- a/cp77backup.py
+++ b/cp77backup.py
@@ -15,15 +15,27 @@ def backup():
     dst_format = "Cyberpunk 2077" + today.strftime("__%d_%b_%Y")
     destination = os.path.join(save_path, dst_format)
 
-    print(f"Source: {source}\nDestination: {destination}")
+    print(f"Source: {source}\nDestination: {destination}")  # Do we need to keep this?
 
-    target_dir = shutil.copytree(source, destination, dirs_exist_ok=True)
-    print(f"Backup raw folder size: {get_dir_size(target_dir)}")
+    source_size = get_dir_size(source)
+
+    print("Compressing backup, please wait ...")
+    target = shutil.make_archive(destination, "zip", source)
+
+    target_size = get_file_size(target)
+
+    print(f"Save folder size: {source_size}, compressed backup size: {target_size}")
     print("Done.")
 
 
-def get_dir_size(target) -> str:
-    raw_size: int = sum(p.stat().st_size for p in Path(target).rglob('*'))
+def get_dir_size(target_dir) -> str:
+    raw_size: int = sum(p.stat().st_size for p in Path(target_dir).rglob('*'))
+    raw_size /= 1024
+    return f"{raw_size:.1f}M"
+
+
+def get_file_size(target_file) -> str:
+    raw_size: int = os.path.getsize(target_file)
     raw_size /= 1024
     return f"{raw_size:.1f}M"
 


### PR DESCRIPTION
Instead of just copying the folder as a backup, compress it to save space. Uses `shutil` instead of anything fancy.